### PR TITLE
fix: revert header to older version while keeping theme toggle

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -16,12 +16,6 @@
     <div class="container">
       <header>
         <div class="header-content">
-          <div class="header-text">
-            <h1>Course Materials Assistant</h1>
-            <p class="subtitle">
-              Ask questions about courses, instructors, and content
-            </p>
-          </div>
           <button id="themeToggle" class="theme-toggle" aria-label="Toggle theme">
             <span class="theme-icon sun-icon">☀️</span>
             <span class="theme-icon moon-icon">🌙</span>

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -76,14 +76,13 @@ body {
 /* Header */
 header {
   background: var(--surface);
-  border-bottom: 1px solid var(--border-color);
   padding: 1rem 2rem;
   transition: var(--theme-transition);
 }
 
 .header-content {
   display: flex;
-  justify-content: space-between;
+  justify-content: flex-end;
   align-items: center;
   max-width: 1200px;
   margin: 0 auto;


### PR DESCRIPTION
Fixes #2

## Summary

Reverted the header to its older, simpler version while preserving the theme toggle functionality.

## Changes
- Removed "Course Materials Assistant" header text
- Removed subheader with "Ask questions about courses, instructors and content"
- Removed horizontal border line below header
- Kept theme toggle functionality intact
- Adjusted header styling to position theme toggle on the right

Generated with [Claude Code](https://claude.ai/code)